### PR TITLE
Remove deprecated option from sshd configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     - regexp: '^GSSAPIAuthentication '
       line: 'GSSAPIAuthentication no'
     - regexp: '^PermitRootLogin '
-      line: 'PermitRootLogin without-password'
+      line: 'PermitRootLogin prohibit-password'
     - regexp: '^KexAlgorithms '
       line: 'KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256'
     - regexp: '^Ciphers '


### PR DESCRIPTION
From the sshd_config man page:

> PermitRootLogin
>
> If this option is set to prohibit-password __(or its deprecated alias, without-password)__, password and keyboard-interactive authentication are disabled for root.

This patch, therefore, updates `without-password` with the non-deprecated variant `prohibit-password`.